### PR TITLE
#14 [상세조회] - ios 이미지 너비 오류 해결

### DIFF
--- a/src/components/Detail/DetailForm.tsx
+++ b/src/components/Detail/DetailForm.tsx
@@ -46,6 +46,7 @@ const Wrapper = styled.div`
 `;
 
 const Img = styled.img`
+  width: 100%;
   min-height: 210px;
   background-color: #dddddd;
 `;


### PR DESCRIPTION
- width 값을 설정해주지 않으니 이미지가 overflow 되는 현상
- width: 100% 설정